### PR TITLE
Non-terminal Iterator

### DIFF
--- a/src/peggo/parse_tree.c
+++ b/src/peggo/parse_tree.c
@@ -23,6 +23,8 @@ parse_t *parse_init(char *s, size_t st, size_t len) {
   tree->children = NULL;
   tree->n_children = 0;
 
+  tree->terminal = false;
+
   return tree;
 }
 

--- a/src/peggo/parse_tree.c
+++ b/src/peggo/parse_tree.c
@@ -84,3 +84,15 @@ size_t parse_total_length(parse_t *tree) {
   }
   return len;
 }
+
+parse_t *parse_non_terminal_begin(parse_t *tree) {
+  return parse_non_terminal_next(tree, tree->children);
+}
+
+parse_t *parse_non_terminal_end(parse_t *tree) {
+  return tree->children + tree->n_children;
+}
+
+parse_t *parse_non_terminal_next(parse_t *tree, parse_t *child) {
+  return NULL;
+}

--- a/src/peggo/parse_tree.c
+++ b/src/peggo/parse_tree.c
@@ -67,7 +67,7 @@ void print_parse_indented(parse_t *tree, int indent) {
 
   print_indents(indent);
 
-  printf("%s [%zu, %zu)\n", tree->symbol, tree->start, tree->start + tree->length);
+  printf("%s [%zu, %zu) %s\n", tree->symbol, tree->start, tree->start + tree->length, tree->terminal?"terminal":"");
   for(size_t i = 0; i < tree->n_children; i++) {
     print_parse_indented(&tree->children[i], indent + 1);
   }
@@ -86,7 +86,7 @@ size_t parse_total_length(parse_t *tree) {
 }
 
 parse_t *parse_non_terminal_begin(parse_t *tree) {
-  return parse_non_terminal_next(tree, tree->children);
+  return parse_non_terminal_next(tree, tree->children - 1);
 }
 
 parse_t *parse_non_terminal_end(parse_t *tree) {
@@ -94,5 +94,12 @@ parse_t *parse_non_terminal_end(parse_t *tree) {
 }
 
 parse_t *parse_non_terminal_next(parse_t *tree, parse_t *child) {
-  return NULL;
+  parse_t *result = child + 1;
+  parse_t *end = parse_non_terminal_end(tree);
+
+  while(result->terminal && result != end) {
+    result++;
+  }
+
+  return result;
 }

--- a/src/peggo/parse_tree.h
+++ b/src/peggo/parse_tree.h
@@ -3,6 +3,7 @@
 #ifndef PARSE_TREE_H
 #define PARSE_TREE_H
 
+#include <stdbool.h>
 #include <stddef.h>
 
 /**
@@ -47,6 +48,18 @@ typedef struct parse_st {
    * The number of child nodes this result has.
    */
   size_t n_children;
+
+  /**
+   * Marks whether this node is a terminal or a non-terminal.
+   *
+   * This can't be reliably computed from other properties of the tree - it's
+   * perfectly valid for a non-terminal to be zero-length or have no children
+   * (if it's made up only of predicates, for example). It is better to set the
+   * property explicitly.
+   *
+   * Set to `false` by default by \ref parse_init.
+   */
+  bool terminal;
 } parse_t;
 
 /**

--- a/src/peggo/parse_tree.h
+++ b/src/peggo/parse_tree.h
@@ -110,4 +110,36 @@ void print_parse(parse_t *tree);
  */
 size_t parse_total_length(parse_t *tree);
 
+/**
+ * Get a pointer to the first non-terminal child node of the given tree.
+ *
+ * If there are no such children, then the returned pointer will be equal to the
+ * end pointer returned by `parse_non_terminal_end`.
+ *
+ * \param tree The parse tree to look for non-terminals in
+ */
+parse_t *parse_non_terminal_begin(parse_t *tree);
+
+/**
+ * Get a pointer to the end of the non-terminal children for the given tree.
+ *
+ * This pointer may not point to allocated memory and as such should never be
+ * dereferenced (only checked for equality with one that has been advanced
+ * through the non-terminals for a tree).
+ *
+ * \param tree The parse tree to look for non-terminals in
+ */
+parse_t *parse_non_terminal_end(parse_t *tree);
+
+/**
+ * Advance a pointer through the non-terminal children of a parse tree.
+ *
+ * If the child tree given is the last one, the return value of this function
+ * will be the same as `parse_non_terminal_end`.
+ *
+ * \param tree The parent tree
+ * \param child The current child pointer to be advanced
+ */
+parse_t *parse_non_terminal_next(parse_t *tree, parse_t *child);
+
 #endif

--- a/src/peggo/parser.c
+++ b/src/peggo/parser.c
@@ -76,6 +76,7 @@ parse_t *parse_terminal(char *source, char *symbol, size_t start, parse_t *paren
   strcpy(annotated + len + 1, "'");
 
   parse_t *ret = parse_init(annotated, start, len);
+  ret->terminal = true;
   parse_add_child(parent, ret);
 
   free(annotated);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,7 +14,19 @@ add_executable(parser_unit_tests
 )
 target_link_libraries(parser_unit_tests cmocka peggo)
 
+add_executable(iterator_unit_tests
+  iterator_main.c
+  test_iterators.c
+)
+target_link_libraries(iterator_unit_tests cmocka peggo)
+
+
 add_test(
   NAME "ParserUnitTests"
   COMMAND ${CMAKE_BINARY_DIR}/test/parser_unit_tests
+)
+
+add_test(
+  NAME "IteratorUnitTests"
+  COMMAND ${CMAKE_BINARY_DIR}/test/iterator_unit_tests
 )

--- a/test/iterator_main.c
+++ b/test/iterator_main.c
@@ -1,0 +1,7 @@
+#include "test.h"
+#include "test_iterator.h"
+
+int main(void) {
+  int iterator_result = test_iterators();
+  return iterator_result;
+}

--- a/test/test_iterator.h
+++ b/test/test_iterator.h
@@ -1,0 +1,8 @@
+#ifndef TEST_PARSER_H
+#define TEST_PARSER_H
+
+#include "test.h"
+
+int test_iterators(void);
+
+#endif

--- a/test/test_iterators.c
+++ b/test/test_iterators.c
@@ -11,7 +11,97 @@ static int teardown(void **state) {
   return 0;
 }
 
+void test_iterator_none(void **state) {
+  grammar_t *grammar = grammar_init(
+    non_terminal("Start"),
+    rule_init(
+      "Start",
+      terminal("hello")
+    ), 1
+  );
+
+  parse_t *result = parse("hello", grammar);
+  parse_t *begin = parse_non_terminal_begin(result);
+  parse_t *end = parse_non_terminal_end(result);
+
+  assert_ptr_equal(begin, end);
+}
+
+void test_iterator_one(void **state) {
+  rule_t *nested = rule_init(
+    "Nested",
+    terminal("hello")
+  );
+
+  rule_t *start = rule_init(
+    "Start",
+    non_terminal("Nested")
+  );
+
+  rule_t rules[] = { *nested, *start };
+
+  grammar_t *grammar = grammar_init(
+    non_terminal("Start"),
+    rules, 2
+  );
+
+  parse_t *result = parse("hello", grammar);
+
+  parse_t *begin = parse_non_terminal_begin(result);
+  parse_t *end = parse_non_terminal_begin(result);
+  assert_ptr_not_equal(begin, end);
+
+  parse_t *next = parse_non_terminal_next(result, begin);
+  assert_ptr_equal(next, end);
+}
+
+void test_iterator_many(void **state) {
+  rule_t *nested = rule_init(
+    "Start",
+    sequence(
+      terminal("hello"),
+      sequence(
+        non_terminal("Space"),
+        non_terminal("World")
+      )
+    ) 
+  );
+
+  rule_t *space = rule_init(
+    "Space",
+    terminal(" ")
+  );
+
+  rule_t *world = rule_init(
+    "World",
+    terminal("world")
+  );
+
+  rule_t rules[] = { *nested, *space, *world };
+
+  grammar_t *grammar = grammar_init(
+    non_terminal("Start"),
+    rules, 4
+  );
+
+  parse_t *result = parse("hello world", grammar);
+  print_parse(result);
+
+  parse_t *begin = parse_non_terminal_begin(result);
+  parse_t *end = parse_non_terminal_begin(result);
+  assert_ptr_not_equal(begin, end);
+
+  parse_t *next = parse_non_terminal_next(result, begin);
+  assert_ptr_not_equal(next, end);
+
+  next = parse_non_terminal_next(result, next);
+  assert_ptr_equal(next, end);
+}
+
 const struct CMUnitTest iterator_tests[] = {
+  cmocka_unit_test(test_iterator_none),
+  cmocka_unit_test(test_iterator_one),
+  cmocka_unit_test(test_iterator_many),
 };
 
 int test_iterators(void) {

--- a/test/test_iterators.c
+++ b/test/test_iterators.c
@@ -48,7 +48,7 @@ void test_iterator_one(void **state) {
   parse_t *result = parse("hello", grammar);
 
   parse_t *begin = parse_non_terminal_begin(result);
-  parse_t *end = parse_non_terminal_begin(result);
+  parse_t *end = parse_non_terminal_end(result);
   assert_ptr_not_equal(begin, end);
 
   parse_t *next = parse_non_terminal_next(result, begin);
@@ -85,10 +85,9 @@ void test_iterator_many(void **state) {
   );
 
   parse_t *result = parse("hello world", grammar);
-  print_parse(result);
 
   parse_t *begin = parse_non_terminal_begin(result);
-  parse_t *end = parse_non_terminal_begin(result);
+  parse_t *end = parse_non_terminal_end(result);
   assert_ptr_not_equal(begin, end);
 
   parse_t *next = parse_non_terminal_next(result, begin);

--- a/test/test_iterators.c
+++ b/test/test_iterators.c
@@ -1,0 +1,19 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include "test_iterator.h"
+
+static int setup(void **state) {
+  return 0;
+}
+
+static int teardown(void **state) {
+  return 0;
+}
+
+const struct CMUnitTest iterator_tests[] = {
+};
+
+int test_iterators(void) {
+  return cmocka_run_group_tests(iterator_tests, setup, teardown);
+}


### PR DESCRIPTION
This adds methods to the parse tree structure that allow a consumer to iterate over the non-terminal nodes in a parse tree.