### PR TITLE
Arithmetic Expression Parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,5 +15,7 @@ mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c11")
 
+include_directories(src/lib)
+
 add_subdirectory(src)
 add_subdirectory(docs)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(lib)
+add_subdirectory(apps)

--- a/src/apps/CMakeLists.txt
+++ b/src/apps/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(ast)

--- a/src/apps/ast/CMakeLists.txt
+++ b/src/apps/ast/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(ast
+  main.c
+  arith_grammar.c
+)
+target_link_libraries(ast peggo)

--- a/src/apps/ast/CMakeLists.txt
+++ b/src/apps/ast/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(ast
   main.c
   arith_grammar.c
+  ast.c
 )
 target_link_libraries(ast peggo)

--- a/src/apps/ast/arith_grammar.c
+++ b/src/apps/ast/arith_grammar.c
@@ -1,0 +1,114 @@
+#include <stdlib.h>
+
+#include "arith_grammar.h"
+
+grammar_t *arith_grammar() {
+  rule_t *rules = malloc(sizeof(*rules) * 9);
+
+  rules[0] = *digit();
+  rules[1] = *sign();
+  rules[2] = *number();
+  rules[3] = *value();
+
+  rules[4] = *add_op();
+  rules[5] = *mul_op();
+
+  rules[6] = *product();
+  rules[7] = *sum();
+  rules[8] = *expr();
+
+  return grammar_init(
+      non_terminal("Expr"),
+      rules, 9);
+}
+
+rule_t *digit() {
+  return rule_init("Digit",
+      choice(
+        terminal("0"), choice(
+        terminal("1"), choice(
+        terminal("2"), choice(
+        terminal("3"), choice(
+        terminal("4"), choice(
+        terminal("5"), choice(
+        terminal("6"), choice(
+        terminal("7"), choice(
+        terminal("8"),
+        terminal("9")
+      ))))))))));
+}
+
+rule_t *sign() {
+  return rule_init("Sign",
+      choice(
+        terminal("-"),
+        terminal("+")
+      ));
+}
+
+rule_t *number() {
+  return rule_init("Number",
+      sequence(
+        optional(non_terminal("Sign")),
+        one_or_more(non_terminal("Digit"))
+      ));
+}
+
+rule_t *value() {
+  return rule_init("Value",
+      choice(
+        non_terminal("Number"),
+        sequence(
+          terminal("("), sequence(
+          non_terminal("Expr"),
+          terminal(")")
+        ))
+      ));
+}
+
+rule_t *add_op() {
+  return rule_init("AddOp",
+      choice(
+        terminal("+"),
+        terminal("-")
+      ));
+}
+
+rule_t *mul_op() {
+  return rule_init("MulOp",
+      choice(
+        terminal("*"),
+        terminal("-")
+      ));
+}
+
+rule_t *product() {
+  return rule_init("Product",
+      sequence(
+        non_terminal("Value"),
+        zero_or_more(
+          sequence(
+            non_terminal("MulOp"),
+            non_terminal("Value")
+          )
+        )
+      ));
+}
+
+rule_t *sum() {
+  return rule_init("Sum",
+      sequence(
+        non_terminal("Product"),
+        zero_or_more(
+          sequence(
+            non_terminal("AddOp"),
+            non_terminal("Product")
+          )
+        )
+      ));
+}
+
+rule_t *expr() {
+  return rule_init("Expr",
+      non_terminal("Sum"));
+}

--- a/src/apps/ast/arith_grammar.c
+++ b/src/apps/ast/arith_grammar.c
@@ -78,7 +78,7 @@ rule_t *mul_op() {
   return rule_init("MulOp",
       choice(
         terminal("*"),
-        terminal("-")
+        terminal("/")
       ));
 }
 

--- a/src/apps/ast/arith_grammar.h
+++ b/src/apps/ast/arith_grammar.h
@@ -1,0 +1,21 @@
+#ifndef ARITH_GRAMMAR_H
+#define ARITH_GRAMMAR_H
+
+#include "peggo.h"
+
+grammar_t *arith_grammar();
+
+rule_t *digit();
+rule_t *sign();
+rule_t *number();
+rule_t *value();
+
+rule_t *add_op();
+rule_t *mul_op();
+
+rule_t *product();
+rule_t *sum();
+
+rule_t *expr();
+
+#endif

--- a/src/apps/ast/ast.c
+++ b/src/apps/ast/ast.c
@@ -1,0 +1,41 @@
+#include <stdlib.h>
+
+#include "ast.h"
+
+ast_t *literal(long long v) {
+  ast_t *node = malloc(sizeof(*node));
+  if(!node) {
+    exit(EXIT_FAILURE);
+  }
+
+  node->type = LEAF;
+  node->value = v;
+
+  return node;
+}
+
+ast_t *op(ast_t *left, op_type ty, ast_t *right) {
+  ast_t *node = malloc(sizeof(*node));
+  if(!node) {
+    exit(EXIT_FAILURE);
+  }
+
+  node->type = BRANCH;
+  node->left = left;
+  node->right = right;
+
+  return node;
+}
+
+void ast_free(ast_t *node) {
+  if(!node) {
+    return;
+  }
+
+  if(node->type == BRANCH) {
+    ast_free(node->left);
+    ast_free(node->right);
+  }
+
+  free(node);
+}

--- a/src/apps/ast/ast.h
+++ b/src/apps/ast/ast.h
@@ -1,0 +1,24 @@
+#ifndef AST_H
+#define AST_H
+
+typedef enum op_type_en {
+  ADD, SUB, MUL, DIV
+} op_type;
+
+typedef enum node_type_en {
+  LEAF, BRANCH
+} node_type;
+
+typedef struct ast_st {
+  op_type op;
+  node_type type;
+  struct ast_st *left;
+  struct ast_st *right;
+  long long value;
+} ast_t;
+
+ast_t *literal(long long v);
+ast_t *op(ast_t *left, op_type op, ast_t *right);
+void ast_free(ast_t *t);
+
+#endif

--- a/src/apps/ast/ast.h
+++ b/src/apps/ast/ast.h
@@ -31,8 +31,9 @@ op_type extract_op(char *src, parse_t *result);
 ast_t *extract(char *src, parse_t *result);
 ast_t *extract_number(char *src, parse_t *result);
 ast_t *extract_value(char *src, parse_t *result);
-ast_t *extract_product(char *src, parse_t *result);
-ast_t *extract_sum(char *src, parse_t *result);
+ast_t *extract_seq(char *src, parse_t *result, size_t off);
 ast_t *extract_expr(char *src, parse_t *result);
+
+long long eval(ast_t *a);
 
 #endif

--- a/src/apps/ast/ast.h
+++ b/src/apps/ast/ast.h
@@ -1,7 +1,10 @@
 #ifndef AST_H
 #define AST_H
 
+#include "peggo.h"
+
 typedef enum op_type_en {
+  INVALID = 0,
   ADD, SUB, MUL, DIV
 } op_type;
 
@@ -20,5 +23,16 @@ typedef struct ast_st {
 ast_t *literal(long long v);
 ast_t *op(ast_t *left, op_type op, ast_t *right);
 void ast_free(ast_t *t);
+
+void print_ast(ast_t *a);
+void print_ast_indented(ast_t *a, int indents);
+
+op_type extract_op(char *src, parse_t *result);
+ast_t *extract(char *src, parse_t *result);
+ast_t *extract_number(char *src, parse_t *result);
+ast_t *extract_value(char *src, parse_t *result);
+ast_t *extract_product(char *src, parse_t *result);
+ast_t *extract_sum(char *src, parse_t *result);
+ast_t *extract_expr(char *src, parse_t *result);
 
 #endif

--- a/src/apps/ast/main.c
+++ b/src/apps/ast/main.c
@@ -2,10 +2,12 @@
 #include "ast.h"
 #include "peggo.h"
 
+ast_t *parse_extract(char *s, grammar_t *g) {
+  return extract(s, parse(s, g));
+}
+
 int main(void) {
   char *source = "(-4*(1+2)+3)";
-  parse_t *result = parse(source, arith_grammar());
-  ast_t *a = extract(source, result);
-  print_ast(a);
+  print_ast(parse_extract(source, arith_grammar()));
   return 0;
 }

--- a/src/apps/ast/main.c
+++ b/src/apps/ast/main.c
@@ -1,10 +1,11 @@
 #include "arith_grammar.h"
+#include "ast.h"
 #include "peggo.h"
 
 int main(void) {
-  print_grammar(arith_grammar());
-  char *source = "1*(2+3*4)*12+(-48)";
+  char *source = "(-4*(1+2)+3)";
   parse_t *result = parse(source, arith_grammar());
-  print_parse(result);
+  ast_t *a = extract(source, result);
+  print_ast(a);
   return 0;
 }

--- a/src/apps/ast/main.c
+++ b/src/apps/ast/main.c
@@ -1,0 +1,10 @@
+#include "arith_grammar.h"
+#include "peggo.h"
+
+int main(void) {
+  print_grammar(arith_grammar());
+  char *source = "1*(2+3*4)*12+(-48)";
+  parse_t *result = parse(source, arith_grammar());
+  print_parse(result);
+  return 0;
+}

--- a/src/apps/ast/main.c
+++ b/src/apps/ast/main.c
@@ -9,8 +9,8 @@ ast_t *parse_extract(char *s, grammar_t *g) {
   return extract(s, parse(s, g));
 }
 
-int main(void) {
-  char *source = "1+2+3+4+5";
+int main(int argc, char **argv) {
+  char *source = argv[1];
   ast_t *a = parse_extract(source, arith_grammar());
   print_ast(a);
   printf("%lld\n", eval(a));

--- a/src/apps/ast/main.c
+++ b/src/apps/ast/main.c
@@ -1,13 +1,18 @@
+#include <stdio.h>
+
 #include "arith_grammar.h"
 #include "ast.h"
 #include "peggo.h"
 
 ast_t *parse_extract(char *s, grammar_t *g) {
+  print_parse(parse(s, g));
   return extract(s, parse(s, g));
 }
 
 int main(void) {
-  char *source = "(-4*(1+2)+3)";
-  print_ast(parse_extract(source, arith_grammar()));
+  char *source = "1+2+3+4+5";
+  ast_t *a = parse_extract(source, arith_grammar());
+  print_ast(a);
+  printf("%lld\n", eval(a));
   return 0;
 }


### PR DESCRIPTION
This PR adds an example application that uses peggo to implement an arithmetic expression parser. It parses an arbitrary infix expression that can include parentheses, then extracts an AST from the parse tree recursively.

It should serve as an initial example of how we might want to build support into the library for extracting ASTs. The style of code used for the extraction is conceptually pretty simple - root non-terminals of some kind know how to get a value from their substring (even if they themselves have children), and leaves know how to construct composite values from their non-terminal children. All tied together by a dispatch function.