### PR TITLE
Get rid of calls to exit()

### DIFF
--- a/src/apps/ast/ast.c
+++ b/src/apps/ast/ast.c
@@ -4,11 +4,12 @@
 
 #include "ast.h"
 #include "common.h"
+#include "log.h"
 
 ast_t *literal(long long v) {
   ast_t *node = malloc(sizeof(*node));
   if(!node) {
-    exit(EXIT_FAILURE);
+    fatal_error("Could not allocate memory for literal AST node");
   }
 
   node->type = LEAF;
@@ -20,7 +21,7 @@ ast_t *literal(long long v) {
 ast_t *op(ast_t *left, op_type ty, ast_t *right) {
   ast_t *node = malloc(sizeof(*node));
   if(!node) {
-    exit(EXIT_FAILURE);
+    fatal_error("Could not allocate memory for binary op AST node");
   }
 
   node->type = BRANCH;
@@ -186,7 +187,6 @@ long long eval(ast_t *a) {
       return eval(a->left) / eval(a->right);
       break;
     default:
-      exit(EXIT_FAILURE);
-      break;
+      fatal_error("Invalid operation when evaluating AST");
   }
 }

--- a/src/lib/expression_construct.c
+++ b/src/lib/expression_construct.c
@@ -2,11 +2,12 @@
 #include <string.h>
 
 #include "expression.h"
+#include "log.h"
 
 expr_t *expr_init(expr_node_t type) {
   expr_t *node = malloc(sizeof(*node));
   if(!node) {
-    exit(EXIT_FAILURE);
+    fatal_error("Could not allocate memory for parsing expression");
   }
 
   node->type = type;
@@ -41,7 +42,7 @@ void init_data(expr_t *node, const char *s) {
 
   node->data = malloc(strlen(s) + 1);
   if(!node->data) {
-    exit(EXIT_FAILURE);
+    fatal_error("Could not allocate memory for parsing expression symbol");
   }
 
   strcpy(node->data, s);

--- a/src/lib/grammar.c
+++ b/src/lib/grammar.c
@@ -3,11 +3,12 @@
 #include <string.h>
 
 #include "grammar.h"
+#include "log.h"
 
 grammar_t *grammar_init(expr_t *st, rule_t *rs, size_t rc) {
   grammar_t *grammar = malloc(sizeof(*grammar));
   if(!grammar) {
-    exit(EXIT_FAILURE);
+    fatal_error("Could not allocate memory for grammar");
   }
 
   grammar->start = st;

--- a/src/lib/log.c
+++ b/src/lib/log.c
@@ -19,7 +19,7 @@ char *level_to_string(unsigned int level) {
 }
 
 void fatal_error(char *message) {
-  fprintf(stderr, "libpeggo fatal error: %s\n", message);
+  fprintf(stderr, "[libpeggo FATAL]: %s\n", message);
   exit(EXIT_FAILURE);
 }
 

--- a/src/lib/log.h
+++ b/src/lib/log.h
@@ -13,7 +13,7 @@
  *
  * \param message The message to log
  */
-void fatal_error(char *message);
+void fatal_error(char *message) __attribute__((noreturn));
 
 /**
  * Log a message to `stderr` at the given level. If the level is greater than

--- a/src/lib/parse_tree.c
+++ b/src/lib/parse_tree.c
@@ -4,16 +4,17 @@
 
 #include "common.h"
 #include "parse_tree.h"
+#include "log.h"
 
 parse_t *parse_init(char *s, size_t st, size_t len) {
   parse_t *tree = malloc(sizeof(parse_t));
   if(!tree) {
-    exit(EXIT_FAILURE);
+    fatal_error("Could not allocate memory for parse tree");
   }
 
   tree->symbol = malloc(strlen(s) + 1); 
   if(!tree->symbol) {
-    exit(EXIT_FAILURE);
+    fatal_error("Could not allocate memory for parse tree symbol");
   }
   strcpy(tree->symbol, s);
 
@@ -52,7 +53,7 @@ void parse_add_child(parse_t *tree, parse_t *child) {
   }
 
   if(!tree->children) {
-    exit(EXIT_FAILURE);
+    fatal_error("Parse tree child pointer is not initialised");
   }
 
   tree->children[tree->n_children] = *child;
@@ -105,7 +106,7 @@ parse_t *parse_collect_non_terminals(parse_t *tree) {
 
   parse_t *buf = malloc(sizeof(*buf) * count);
   if(!buf) {
-    exit(EXIT_FAILURE);
+    fatal_error("Could not allocate memory for non-terminal collection buffer");
   }
 
   parse_t *child = parse_non_terminal_begin(tree);

--- a/src/lib/parser.c
+++ b/src/lib/parser.c
@@ -4,6 +4,7 @@
 
 #include "parser.h"
 #include "parser_p.h"
+#include "log.h"
 
 static _Thread_local grammar_t *grammar;
 
@@ -46,8 +47,7 @@ parse_t *parse_dispatch(char *source, expr_t *rule, size_t start, parse_t *paren
     case Node_Not:
       return parse_not(source, rule->left, start);
     default:
-      printf("Invalid node in grammar - fatal error\n");
-      exit(EXIT_FAILURE);
+      fatal_error("Invalid node in grammar");
   }
 
   return NULL;
@@ -68,7 +68,7 @@ parse_t *parse_terminal(char *source, char *symbol, size_t start, parse_t *paren
 
   char *annotated = malloc(len + 2);
   if(!annotated) {
-    exit(EXIT_FAILURE);
+    fatal_error("Could not allocate memory for annotated terminal symbol");
   }
 
   strcpy(annotated, "'");
@@ -86,8 +86,7 @@ parse_t *parse_terminal(char *source, char *symbol, size_t start, parse_t *paren
 parse_t *parse_non_terminal(char *source, char *symbol, size_t start, parse_t *parent) {
   rule_t *rule = grammar_production(grammar, symbol);
   if(!rule) {
-    printf("Invalid grammar - no rule for non-terminal %s\n", symbol);
-    exit(EXIT_FAILURE);
+    fatal_error("Invalid grammar - no rule for a non-terminal");
   }
 
   parse_t *this = parse_init(symbol, start, 0);

--- a/src/lib/rule.c
+++ b/src/lib/rule.c
@@ -3,16 +3,17 @@
 #include <string.h>
 
 #include "rule.h"
+#include "log.h"
 
 rule_t *rule_init(char *sym, expr_t *expr) {
   rule_t *rule = malloc(sizeof(rule_t));
   if(!rule) {
-    exit(EXIT_FAILURE);
+    fatal_error("Could not allocate memory for rule");
   }
 
   rule->symbol = malloc(strlen(sym) + 1);
   if(!rule->symbol) {
-    exit(EXIT_FAILURE);
+    fatal_error("Could not allocate memory for rule symbol");
   }
 
   strcpy(rule->symbol, sym);


### PR DESCRIPTION
This means that `fatal_error` is now the primary way for code to
abnormally terminate the program in exceptional circumstances.