### PR TITLE
Fix Cmocka CMake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,6 @@ project(Peggo)
 
 find_package(cmocka)
 if(${cmocka_FOUND})
-  message(STATUS ${CMOCKA_INCLUDE_DIR})
   include_directories(${CMOCKA_INCLUDE_DIR})
   enable_testing()
   message(STATUS "Found cmocka, enabling unit tests")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ project(Peggo)
 
 find_package(cmocka)
 if(${cmocka_FOUND})
+  message(STATUS ${CMOCKA_INCLUDE_DIR})
+  include_directories(${CMOCKA_INCLUDE_DIR})
   enable_testing()
   message(STATUS "Found cmocka, enabling unit tests")
   add_subdirectory(test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,13 +12,13 @@ add_executable(parser_unit_tests
   test_parser_and.c
   test_parser_not.c
 )
-target_link_libraries(parser_unit_tests cmocka peggo)
+target_link_libraries(parser_unit_tests ${CMOCKA_LIBRARY} peggo)
 
 add_executable(iterator_unit_tests
   iterator_main.c
   test_iterators.c
 )
-target_link_libraries(iterator_unit_tests cmocka peggo)
+target_link_libraries(iterator_unit_tests ${CMOCKA_LIBRARY} peggo)
 
 
 add_test(


### PR DESCRIPTION
This makes CMake search for CMocka properly (including the library name and include path when they aren't coincidentally on a system path).