### PR TITLE
Logging config

### DIFF
--- a/src/apps/ast/arith_grammar.c
+++ b/src/apps/ast/arith_grammar.c
@@ -3,19 +3,11 @@
 #include "arith_grammar.h"
 
 grammar_t *arith_grammar() {
-  rule_t *rules = malloc(sizeof(*rules) * 9);
-
-  rules[0] = *digit();
-  rules[1] = *sign();
-  rules[2] = *number();
-  rules[3] = *value();
-
-  rules[4] = *add_op();
-  rules[5] = *mul_op();
-
-  rules[6] = *product();
-  rules[7] = *sum();
-  rules[8] = *expr();
+  rule_t *rules = rule_collect(9,
+    digit, sign, number, value,
+    add_op, mul_op,
+    product, sum, expr
+  );
 
   return grammar_init(
       non_terminal("Expr"),

--- a/src/lib/log.c
+++ b/src/lib/log.c
@@ -3,6 +3,20 @@
 
 #include "log.h"
 
+FILE *log_file = NULL;
+
+FILE *get_log_file() {
+  if(log_file) {
+    return log_file;
+  }
+
+  return stderr;
+}
+
+void log_redirect(FILE *f) {
+  log_file = f;
+}
+
 char *level_to_string(unsigned int level) {
   switch(level) {
     case 1:
@@ -19,12 +33,12 @@ char *level_to_string(unsigned int level) {
 }
 
 void fatal_error(char *message) {
-  fprintf(stderr, "[libpeggo FATAL]: %s\n", message);
+  fprintf(get_log_file(), "[libpeggo FATAL]: %s\n", message);
   exit(EXIT_FAILURE);
 }
 
 void log_level(unsigned int level, char *message) {
   if(level <= DEBUG_LEVEL) {
-    fprintf(stderr, "libpeggo [%s]: %s\n", level_to_string(level), message);
+    fprintf(get_log_file(), "libpeggo [%s]: %s\n", level_to_string(level), message);
   }
 }

--- a/src/lib/log.h
+++ b/src/lib/log.h
@@ -3,9 +3,21 @@
 #ifndef LOG_H
 #define LOG_H
 
+#include <stdio.h>
+
 #ifndef DEBUG_LEVEL
 #define DEBUG_LEVEL 4
 #endif
+
+/**
+ * Redirect logging to another file.
+ *
+ * Logs are sent to `stdout` by default, but they can be sent to any open file
+ * by using this method.
+ *
+ * \param f The file to log to.
+ */
+void log_redirect(FILE *f);
 
 /**
  * Logs a message to `stderr`, then exits the program with a nonzero return

--- a/src/lib/rule.c
+++ b/src/lib/rule.c
@@ -1,3 +1,4 @@
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -22,6 +23,11 @@ rule_t *rule_init(char *sym, expr_t *expr) {
 }
 
 void rule_free(rule_t *rule) {
+  rule_free_unowned(rule);
+  free(rule);
+}
+
+void rule_free_unowned(rule_t *rule) {
   if(!rule) {
     return;
   }
@@ -29,6 +35,32 @@ void rule_free(rule_t *rule) {
   expr_free(rule->production);
   free(rule->symbol);
   free(rule);
+}
+
+rule_t *rule_collect(size_t count, ...) {
+  va_list ap;
+  rule_t *rules = malloc(sizeof(rule_t) * count);
+  if(!rules) {
+    fatal_error("Could not allocate memory for rule collection");
+  }
+
+  va_start(ap, count);
+  for(size_t i = 0; i < count; i++) {
+    rule_t *(*create)(void) = va_arg(ap, rule_t *(*)(void));
+    rule_t *newRule = create();
+    rules[i] = *newRule;
+    free(newRule);
+  }
+  va_end(ap);
+
+  return rules;
+}
+
+void rule_collect_free(size_t count, rule_t *rules) {
+  for(size_t i = 0; i < count; i++) {
+    rule_free_unowned(&rules[i]);
+  }
+  free(rules);
 }
 
 void print_rule(rule_t *rule) {

--- a/src/lib/rule.h
+++ b/src/lib/rule.h
@@ -39,10 +39,43 @@ rule_t *rule_init(char *sym, expr_t *expr);
  */
 void rule_free(rule_t *rule);
 
+/**
+ * Recursively free a rule when the pointer to the rule itself is not owned.
+ *
+ * This is the case when the rule is contained within a larger structure
+ * deliberately (e.g. as a struct member or an array element), such that freeing
+ * the pointer to the rule would be invalid.
+ *
+ * Should not be used without also freeing the memory containing the rule.
+ *
+ * \param rule The rule to free
+ */
 void rule_free_unowned(rule_t *rule);
 
+/**
+ * Collect a number of rules into a contiguous array.
+ *
+ * This is a convenience method that allows for rules to be computed and stored
+ * together without manually constructing an array.
+ *
+ * The pointer returned by this method should be freed by calling \ref
+ * rule_collect_free with the correct count.
+ *
+ * \param count The number of rules to allocate memory for
+ * \param ... Variadic argument containing the rules to be constructed. Each
+ *            element of the variadic array should be a function declared as
+ *            either `rule_t *()` or `rule_t *(void)`.
+ */
 rule_t *rule_collect(size_t count, ...);
 
+/**
+ * Free a continuous array of rules allocated by \ref rule_collect.
+ *
+ * This should not be called on memory allocated by different functions.
+ *
+ * \param count The number of rules to be freed
+ * \param rules The array containing rules to be freed
+ */
 void rule_collect_free(size_t count, rule_t *rules);
 
 /**

--- a/src/lib/rule.h
+++ b/src/lib/rule.h
@@ -39,6 +39,12 @@ rule_t *rule_init(char *sym, expr_t *expr);
  */
 void rule_free(rule_t *rule);
 
+void rule_free_unowned(rule_t *rule);
+
+rule_t *rule_collect(size_t count, ...);
+
+void rule_collect_free(size_t count, rule_t *rules);
+
 /**
  * Pretty-print a production rule to `STDOUT`.
  *


### PR DESCRIPTION
Allow for logs to be redirected to any open file, rather than just `stderr`.

Implements #41 