### PR TITLE
Parsing Primitives

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(peggo
   common.c
   parser.c
   log.c
+  primitives.c
 )
 
 set(headers
@@ -21,6 +22,7 @@ set(headers
   rule.h
   grammar.h
   peggo.h
+  primitives.h
 )
 set_target_properties(peggo
   PROPERTIES PUBLIC_HEADER "${headers}"

--- a/src/lib/peggo.h
+++ b/src/lib/peggo.h
@@ -6,5 +6,6 @@
 #include "grammar.h"
 #include "rule.h"
 #include "parse_tree.h"
+#include "primitives.h"
 
 #endif

--- a/src/lib/primitives.c
+++ b/src/lib/primitives.c
@@ -1,0 +1,1 @@
+#include "primitives.h"

--- a/src/lib/primitives.c
+++ b/src/lib/primitives.c
@@ -10,3 +10,13 @@ expr_t *sep_by(expr_t *e, expr_t *s) {
     )
   );
 }
+
+
+expr_t *whitespace() {
+  return zero_or_more(
+    choice(
+      terminal(" "),
+      terminal("\t")
+    )
+  );
+}

--- a/src/lib/primitives.c
+++ b/src/lib/primitives.c
@@ -19,3 +19,13 @@ expr_t *whitespace() {
     )
   );
 }
+
+expr_t *wrapped(expr_t *left, expr_t *inner, expr_t *right) {
+  return sequence(
+    sequence(
+      left,
+      inner
+    ),
+    right
+  );
+}

--- a/src/lib/primitives.c
+++ b/src/lib/primitives.c
@@ -11,7 +11,6 @@ expr_t *sep_by(expr_t *e, expr_t *s) {
   );
 }
 
-
 expr_t *whitespace() {
   return zero_or_more(
     choice(

--- a/src/lib/primitives.c
+++ b/src/lib/primitives.c
@@ -1,1 +1,12 @@
 #include "primitives.h"
+
+expr_t *sep_by(expr_t *e, expr_t *s) {
+  return optional(
+    sequence(
+      e,
+      zero_or_more(
+        sequence(s, e)
+      )
+    )
+  );
+}

--- a/src/lib/primitives.h
+++ b/src/lib/primitives.h
@@ -16,4 +16,12 @@
  */
 expr_t *sep_by(expr_t *expr, expr_t *sep);
 
+/**
+ * Parse whitespace that does not extend over a line boundary.
+ *
+ * This expression matches zero or more spaces or tabs, but will not match line
+ * separators like '\n'.
+ */
+expr_t *whitespace();
+
 #endif

--- a/src/lib/primitives.h
+++ b/src/lib/primitives.h
@@ -1,4 +1,19 @@
+/** @file */
+
 #ifndef PRIMITIVES_H
 #define PRIMITIVES_H
+
+#include "expression.h"
+
+/**
+ * Parse a sequence of expressions separated by another expression.
+ *
+ * This parsing expression will match zero or more instances of \p expr, provided
+ * that between each instance of \p expr, there is an instance of \p sep.
+ *
+ * \param expr The expression in sequence
+ * \param sep The separator
+ */
+expr_t *sep_by(expr_t *expr, expr_t *sep);
 
 #endif

--- a/src/lib/primitives.h
+++ b/src/lib/primitives.h
@@ -1,0 +1,4 @@
+#ifndef PRIMITIVES_H
+#define PRIMITIVES_H
+
+#endif

--- a/src/lib/primitives.h
+++ b/src/lib/primitives.h
@@ -24,4 +24,16 @@ expr_t *sep_by(expr_t *expr, expr_t *sep);
  */
 expr_t *whitespace();
 
+/**
+ * Parse an expression that is wrapped inside a pair of outer expressions.
+ *
+ * An example of this could be an expression wrapped in parentheses. This
+ * expression will match exactly one left, one inner, then one right.
+ *
+ * \param left The left-hand expression
+ * \param inner The inner expression
+ * \param right The right-hand expression
+ */
+expr_t *wrapped(expr_t *left, expr_t *inner, expr_t *right);
+
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(parser_unit_tests
   test_parser_and.c
   test_parser_not.c
   test_parser_sep_by.c
+  test_parser_whitespace.c
 )
 target_link_libraries(parser_unit_tests ${CMOCKA_LIBRARY} peggo)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(parser_unit_tests
   test_parser_not.c
   test_parser_sep_by.c
   test_parser_whitespace.c
+  test_parser_wrapped.c
 )
 target_link_libraries(parser_unit_tests ${CMOCKA_LIBRARY} peggo)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(parser_unit_tests
   test_parser_optional.c
   test_parser_and.c
   test_parser_not.c
+  test_parser_sep_by.c
 )
 target_link_libraries(parser_unit_tests ${CMOCKA_LIBRARY} peggo)
 

--- a/test/test.h
+++ b/test/test.h
@@ -5,6 +5,6 @@
 #include <stddef.h>
 #include <setjmp.h>
 #include <cmocka.h>
-#include "../src/lib/parser.h"
+#include "../src/lib/peggo.h"
 
 #endif

--- a/test/test_parser.c
+++ b/test/test_parser.c
@@ -58,6 +58,11 @@ const struct CMUnitTest parser_tests[] = {
   cmocka_unit_test(whitespace_tabs),
   cmocka_unit_test(whitespace_mixed),
   cmocka_unit_test(whitespace_newlines),
+
+  cmocka_unit_test(wrapped_no_end),
+  cmocka_unit_test(wrapped_no_start),
+  cmocka_unit_test(wrapped_no_inner),
+  cmocka_unit_test(wrapped_success),
 };
 
 int test_parser(void) {

--- a/test/test_parser.c
+++ b/test/test_parser.c
@@ -47,6 +47,11 @@ const struct CMUnitTest parser_tests[] = {
 
   cmocka_unit_test(not_true),
   cmocka_unit_test(not_false),
+
+  cmocka_unit_test(sep_by_zero),
+  cmocka_unit_test(sep_by_one),
+  cmocka_unit_test(sep_by_many),
+  cmocka_unit_test(sep_by_fail),
 };
 
 int test_parser(void) {

--- a/test/test_parser.c
+++ b/test/test_parser.c
@@ -52,6 +52,12 @@ const struct CMUnitTest parser_tests[] = {
   cmocka_unit_test(sep_by_one),
   cmocka_unit_test(sep_by_many),
   cmocka_unit_test(sep_by_fail),
+
+  cmocka_unit_test(whitespace_none),
+  cmocka_unit_test(whitespace_spaces),
+  cmocka_unit_test(whitespace_tabs),
+  cmocka_unit_test(whitespace_mixed),
+  cmocka_unit_test(whitespace_newlines),
 };
 
 int test_parser(void) {

--- a/test/test_parser_p.h
+++ b/test/test_parser_p.h
@@ -40,4 +40,10 @@ void and_true(void **state);
 void not_true(void **state);
 void not_false(void **state);
 
+void sep_by_zero(void **state);
+void sep_by_one(void **state);
+void sep_by_many(void **state);
+
+void sep_by_fail(void **state);
+
 #endif

--- a/test/test_parser_p.h
+++ b/test/test_parser_p.h
@@ -46,4 +46,10 @@ void sep_by_many(void **state);
 
 void sep_by_fail(void **state);
 
+void whitespace_none(void **state);
+void whitespace_spaces(void **state);
+void whitespace_tabs(void **state);
+void whitespace_mixed(void **state);
+void whitespace_newlines(void **state);
+
 #endif

--- a/test/test_parser_p.h
+++ b/test/test_parser_p.h
@@ -52,4 +52,9 @@ void whitespace_tabs(void **state);
 void whitespace_mixed(void **state);
 void whitespace_newlines(void **state);
 
+void wrapped_no_end(void **state);
+void wrapped_no_start(void **state);
+void wrapped_no_inner(void **state);
+void wrapped_success(void **state);
+
 #endif

--- a/test/test_parser_sep_by.c
+++ b/test/test_parser_sep_by.c
@@ -1,0 +1,85 @@
+#include "test_parser_p.h"
+
+void sep_by_zero(void **state) {
+  grammar_t *grammar = grammar_init(
+    non_terminal("Start"),
+    rule_init("Start",
+      sep_by(
+        terminal("hello"),
+        terminal(",")
+      )
+    ), 1);
+
+  parse_t *result = parse("", grammar);
+  assert_non_null(result);
+
+  assert_int_equal(result->length, 0);
+  assert_int_equal(result->n_children, 0);
+  assert_string_equal(result->symbol, "Start");
+}
+
+void sep_by_one(void **state) {
+  grammar_t *grammar = grammar_init(
+    non_terminal("Start"),
+    rule_init("Start",
+      sep_by(
+        terminal("hello"),
+        terminal(",")
+      )
+    ), 1);
+
+  parse_t *result = parse("hello", grammar);
+  assert_non_null(result);
+
+  assert_int_equal(result->length, 5);
+  assert_int_equal(result->n_children, 1);
+  assert_string_equal(result->symbol, "Start");
+
+  assert_int_equal(result->children[0].length, 5);
+}
+
+void sep_by_many(void **state) {
+  grammar_t *grammar = grammar_init(
+    non_terminal("Start"),
+    rule_init("Start",
+      sep_by(
+        terminal("hello"),
+        terminal(",")
+      )
+    ), 1);
+
+  parse_t *result = parse("hello,hello,hello", grammar);
+  assert_non_null(result);
+
+  assert_int_equal(result->length, 17);
+  assert_int_equal(result->n_children, 5);
+  assert_string_equal(result->symbol, "Start");
+
+  assert_int_equal(result->children[0].length, 5);
+  assert_int_equal(result->children[1].length, 1);
+  assert_int_equal(result->children[2].length, 5);
+  assert_int_equal(result->children[3].length, 1);
+  assert_int_equal(result->children[4].length, 5);
+}
+
+void sep_by_fail(void **state) {
+  grammar_t *grammar = grammar_init(
+    non_terminal("Start"),
+    rule_init("Start",
+      sep_by(
+        terminal("hello"),
+        terminal(",")
+      )
+    ), 1);
+
+  parse_t *result = parse("hello,hello hello", grammar);
+  assert_non_null(result);
+
+  assert_int_equal(result->length, 11);
+  assert_int_equal(result->n_children, 3);
+  assert_string_equal(result->symbol, "Start");
+
+  assert_int_equal(result->children[0].length, 5);
+  assert_int_equal(result->children[1].length, 1);
+  assert_int_equal(result->children[2].length, 5);
+}

--- a/test/test_parser_whitespace.c
+++ b/test/test_parser_whitespace.c
@@ -1,0 +1,80 @@
+#include "test_parser.h"
+
+void whitespace_none(void **state) {
+  grammar_t *grammar = grammar_init(
+    non_terminal("Start"),
+    rule_init(
+      "Start",
+      whitespace()
+    ), 1
+  );
+
+  parse_t *result = parse("none", grammar);
+  assert_non_null(result);
+
+  assert_int_equal(result->length, 0);
+}
+
+void whitespace_spaces(void **state) {
+  grammar_t *grammar = grammar_init(
+    non_terminal("Start"),
+    rule_init(
+      "Start",
+      whitespace()
+    ), 1
+  );
+
+  parse_t *result = parse("    ", grammar);
+  assert_non_null(result);
+
+  assert_int_equal(result->length, 4);
+  assert_int_equal(result->n_children, 4);
+}
+
+void whitespace_tabs(void **state) {
+  grammar_t *grammar = grammar_init(
+    non_terminal("Start"),
+    rule_init(
+      "Start",
+      whitespace()
+    ), 1
+  );
+
+  parse_t *result = parse("\t\t", grammar);
+  assert_non_null(result);
+
+  assert_int_equal(result->length, 2);
+  assert_int_equal(result->n_children, 2);
+}
+
+void whitespace_mixed(void **state) {
+  grammar_t *grammar = grammar_init(
+    non_terminal("Start"),
+    rule_init(
+      "Start",
+      whitespace()
+    ), 1
+  );
+
+  parse_t *result = parse(" \t \t ", grammar);
+  assert_non_null(result);
+
+  assert_int_equal(result->length, 5);
+  assert_int_equal(result->n_children, 5);
+}
+
+void whitespace_newlines(void **state) {
+  grammar_t *grammar = grammar_init(
+    non_terminal("Start"),
+    rule_init(
+      "Start",
+      whitespace()
+    ), 1
+  );
+
+  parse_t *result = parse("  \n\t", grammar);
+  assert_non_null(result);
+
+  assert_int_equal(result->length, 2);
+  assert_int_equal(result->n_children, 2);
+}

--- a/test/test_parser_wrapped.c
+++ b/test/test_parser_wrapped.c
@@ -1,0 +1,72 @@
+#include "test_parser.h"
+
+void wrapped_no_end(void **state) {
+  grammar_t *grammar = grammar_init(
+    non_terminal("Start"),
+    rule_init(
+      "Start",
+      wrapped(
+        terminal("["),
+        terminal("hello"),
+        terminal("]")
+      )
+    ), 1
+  );
+
+  parse_t *result = parse("[hello", grammar);
+  assert_null(result);
+}
+
+void wrapped_no_start(void **state) {
+  grammar_t *grammar = grammar_init(
+    non_terminal("Start"),
+    rule_init(
+      "Start",
+      wrapped(
+        terminal("["),
+        terminal("hello"),
+        terminal("]")
+      )
+    ), 1
+  );
+
+  parse_t *result = parse("hello]", grammar);
+  assert_null(result);
+}
+
+void wrapped_no_inner(void **state) {
+  grammar_t *grammar = grammar_init(
+    non_terminal("Start"),
+    rule_init(
+      "Start",
+      wrapped(
+        terminal("["),
+        terminal("hello"),
+        terminal("]")
+      )
+    ), 1
+  );
+
+  parse_t *result = parse("[yo]", grammar);
+  assert_null(result);
+}
+
+void wrapped_success(void **state) {
+  grammar_t *grammar = grammar_init(
+    non_terminal("Start"),
+    rule_init(
+      "Start",
+      wrapped(
+        terminal("["),
+        terminal("hello"),
+        terminal("]")
+      )
+    ), 1
+  );
+
+  parse_t *result = parse("[hello]", grammar);
+  assert_non_null(result);
+
+  assert_int_equal(result->n_children, 3);
+  assert_int_equal(result->length, 7);
+}


### PR DESCRIPTION
This is a work in progress to implement a library of parsing primitives as described in #33.

Currently implemented:
* `sep_by`
* `whitespace`
* `wrapped`