### PR TITLE
New parse result type

### DIFF
--- a/src/lib/parser.c
+++ b/src/lib/parser.c
@@ -8,6 +8,70 @@
 
 static _Thread_local grammar_t *grammar;
 
+parse_error_t *parse_error_init(char *message) {
+  parse_error_t *err = malloc(sizeof(*err));
+  if(!err) {
+    fatal_error("Could not allocate memory for parse error");
+  }
+  
+  err->message = malloc(strlen(message) + 1);
+  if(!err->message) {
+    fatal_error("Could not allocate memory for parse error message");
+  }
+  strcpy(err->message, message);
+  
+  return err;
+}
+
+void parse_error_free(parse_error_t *err) {
+  if(!err) {
+    return;
+  }
+
+  free(err->message);
+  free(err);
+}
+
+parse_result_t *parse_result_init() {
+  parse_result_t *res = malloc(sizeof(*res));
+  if(!res) {
+    fatal_error("Could not allocate memory for parse result");
+  }
+
+  return res;
+}
+
+parse_result_t *make_result(parse_t *result) {
+  parse_result_t *res = parse_result_init();
+  res->data.result = result;
+  res->data_kind = RESULT;
+  return res;
+}
+
+parse_result_t *make_error(parse_error_t *error) {
+  parse_result_t *res = parse_result_init();
+  res->data.error = error;
+  res->data_kind = ERROR;
+  return res;
+}
+
+void parse_result_free(parse_result_t *result) {
+  if(!result) {
+    return;
+  }
+
+  switch(result->data_kind) {
+    case RESULT:
+      parse_free(result->data.result);
+      break;
+    case ERROR:
+      parse_error_free(result->data.error);
+      break;
+  }
+
+  free(result);
+}
+
 parse_t *parse(char *source, grammar_t *gram) {
   grammar = gram;
 

--- a/src/lib/parser.h
+++ b/src/lib/parser.h
@@ -7,6 +7,95 @@
 #include "parse_tree.h"
 
 /**
+ * Tag type for parse results.
+ *
+ * Describes if the result of a parse is an error or holds some data.
+ */
+enum parse_result_kind {
+  ERROR = 0,
+  RESULT
+};
+
+/**
+ * Holds information about a parsing error.
+ */
+typedef struct parse_error_st {
+  /**
+   * A message describing the error that occured.
+   */
+  char *message;
+} parse_error_t;
+
+/**
+ * Tagged union type that can hold a parsing error or a valid result.
+ */
+typedef struct parse_result_st {
+  /**
+   * The parsing data (error or valid result).
+   */
+  union {
+    parse_t *result;
+    parse_error_t *error;
+  } data;
+
+  /**
+   * Tag specifying which kind of data is stored in the union.
+   */
+  enum parse_result_kind data_kind;
+} parse_result_t;
+
+/**
+ * Initialise a parse error structure with a message.
+ *
+ * The string passed is copied into the error structure. Errors allocated using
+ * this method should only be freed using \ref parse_error_free.
+ *
+ * \param message String describing the error
+ */
+parse_error_t *parse_error_init(char *message);
+
+/**
+ * Free a parse error structure.
+ *
+ * This should only be used on errors allocated with \ref parse_error_init.
+ *
+ * \param err The error to be freed. May be `NULL`.
+ */
+void parse_error_free(parse_error_t *err);
+
+/**
+ * Wrap a \ref parse_t result into a \ref parse_result_t.
+ *
+ * The \ref parse_t passed is owned by the returned structure. The pointer
+ * returned from this function should only be freed using \ref
+ * parse_result_free.
+ *
+ * \param result The successful result to be encapsulated.
+ */
+parse_result_t *make_result(parse_t *result);
+
+/**
+ * Wrap a \ref parse_error_t error into a \ref parse_result_t.
+ *
+ * The \ref parse_error_t passed is owned by the returned structure. The pointer
+ * returned from this function should only be freed using \ref
+ * parse_result_free.
+ *
+ * \param error The error to be encapsulated.
+ */
+parse_result_t *make_error(parse_error_t *error);
+
+/**
+ * Free a \ref parse_result_t.
+ *
+ * This function frees the data stored in the result (whether it is a success or
+ * an error).
+ *
+ * \param result The result to be freed. May be `NULL`.
+ */
+void parse_result_free(parse_result_t *result);
+
+/**
  * Parse a string using a PEG grammar.
  *
  * This function is **not** thread safe, as \p grammar is stored in a global


### PR DESCRIPTION
This type will be used to give better control over what is returned and
passed through the parser internally.

The next steps will be to use this inside the parser as appropriate.

Implements #52 